### PR TITLE
User-Specific Search History with Clerk Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,10 @@ This project is a Library Management Application. It allows users to explore boo
 - In the **frontend**, I used `<ClerkProvider>` to set up Clerk and added `<SignInButton>`, `<UserButton>`, `<SignedIn>`, and `<SignedOut>` to manage user login and display appropriate buttons.
 - In the **backend**, I added `clerkMiddleware` and used `requireAuth()` to protect routes, so only signed-in users can create or delete data, while public routes remain open.
 
+###  I.1: Custom User-Associated Data and Session Management (P1)
+- This project implements user-specific search history using Clerk authentication and Prisma.  
+- Logged-in users can save and view their personal search history, while guest users can still search without saving data.
+
 ### T.4: Local Setup Instructions (P2) - Manjot
 
 ## Local Setup

--- a/apps/backend/prisma/migrations/20260331172224_update_schema/migration.sql
+++ b/apps/backend/prisma/migrations/20260331172224_update_schema/migration.sql
@@ -2,6 +2,5 @@
 CREATE TABLE "SearchFilter" (
     "id" SERIAL NOT NULL,
     "term" TEXT NOT NULL,
-
     CONSTRAINT "SearchFilter_pkey" PRIMARY KEY ("id")
 );

--- a/apps/backend/prisma/migrations/20260331181546_add_library_tip/migration.sql
+++ b/apps/backend/prisma/migrations/20260331181546_add_library_tip/migration.sql
@@ -1,12 +1,4 @@
 -- CreateTable
-CREATE TABLE "SearchFilter" (
-    "id" SERIAL NOT NULL,
-    "term" TEXT NOT NULL,
-
-    CONSTRAINT "SearchFilter_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
 CREATE TABLE "LibraryTip" (
     "id" SERIAL NOT NULL,
     "title" TEXT NOT NULL,

--- a/apps/backend/prisma/migrations/20260424045738_init/migration.sql
+++ b/apps/backend/prisma/migrations/20260424045738_init/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `userId` to the `SearchFilter` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "SearchFilter" ADD COLUMN     "userId" INTEGER NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "SearchFilter" ADD CONSTRAINT "SearchFilter_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -13,11 +13,16 @@ model User {
   name     String
   email    String @unique
   books    Book[]
+  
+  searches SearchFilter[]
 }
 
 model SearchFilter {
   id   Int    @id @default(autoincrement())
   term String
+  
+  userId Int
+  user   User @relation(fields: [userId], references: [id])
 }
 
 model Book {

--- a/apps/backend/src/controllers/searchFilterController.ts
+++ b/apps/backend/src/controllers/searchFilterController.ts
@@ -12,6 +12,7 @@ export const getSearchHistory = async (req: Request, res: Response) => {
 
 export const createSearch = async (req: Request, res: Response) => {
   try {
+    console.log("HIT CREATE API", req.body);
     const { term } = req.body;
     const newItem = await searchFilterService.create(term);
     res.status(201).json(newItem);

--- a/apps/backend/src/controllers/searchFilterController.ts
+++ b/apps/backend/src/controllers/searchFilterController.ts
@@ -1,9 +1,25 @@
 import { Request, Response } from "express";
 import { searchFilterService } from "../services/searchFilterService";
+import { prisma } from "../services/prisma";
 
 export const getSearchHistory = async (req: Request, res: Response) => {
   try {
-    const data = await searchFilterService.getAll();
+    const clerkId = (req as any).auth?.userId;
+
+    if (!clerkId) {
+      return res.json([]);
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { clerkId },
+    });
+
+    if (!user) {
+      return res.json([]);
+    }
+
+    const data = await searchFilterService.getAll(user.id);
+
     res.json(data);
   } catch (error) {
     res.status(500).json({ error: "Failed to fetch search history" });
@@ -12,9 +28,29 @@ export const getSearchHistory = async (req: Request, res: Response) => {
 
 export const createSearch = async (req: Request, res: Response) => {
   try {
-    console.log("HIT CREATE API", req.body);
+    const clerkId = (req as any).auth?.userId;
     const { term } = req.body;
-    const newItem = await searchFilterService.create(term);
+
+    if (!clerkId) {
+      return res.status(401).json({ error: "Unauthorized  - no Clerk session"});
+    }
+
+    let user = await prisma.user.findUnique({
+      where: { clerkId },
+    });
+
+    if (!user) {
+      user = await prisma.user.create({
+        data: {
+          clerkId,
+          name: "New User",
+          email: `${clerkId}@temp.com`,
+        },
+      });
+    }
+
+    const newItem = await searchFilterService.create(term, user.id);
+
     res.status(201).json(newItem);
   } catch (error) {
     res.status(500).json({ error: "Failed to create search term" });
@@ -23,8 +59,23 @@ export const createSearch = async (req: Request, res: Response) => {
 
 export const deleteSearch = async (req: Request, res: Response) => {
   try {
+    const clerkId = (req as any).auth?.userId;
     const id = Number(req.params.id);
-    await searchFilterService.remove(id);
+
+    if (!clerkId) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { clerkId },
+    });
+
+    if (!user) {
+      return res.status(401).json({ error: "User not found" });
+    }
+
+    await searchFilterService.remove(id, user.id);
+
     res.json({ message: "Deleted successfully" });
   } catch (error) {
     res.status(500).json({ error: "Failed to delete search term" });

--- a/apps/backend/src/middleware/auth.ts
+++ b/apps/backend/src/middleware/auth.ts
@@ -1,0 +1,9 @@
+import { clerkMiddleware, getAuth } from "@clerk/express";
+
+export const clerkAuth = clerkMiddleware();
+
+export const attachAuth = (req: any, res: any, next: any) => {
+  const auth = getAuth(req);
+  req.auth = auth;
+  next();
+};

--- a/apps/backend/src/routes/searchFilterRoutes.ts
+++ b/apps/backend/src/routes/searchFilterRoutes.ts
@@ -9,7 +9,7 @@ import { requireAuth } from "@clerk/express";
 const router = Router();
 
 router.get("/", getSearchHistory);
-router.post("/", requireAuth(), validateSearch, createSearch);
+router.post("/", validateSearch, createSearch);
 router.delete("/:id", requireAuth(), deleteSearch);
 
 export default router;

--- a/apps/backend/src/routes/searchFilterRoutes.ts
+++ b/apps/backend/src/routes/searchFilterRoutes.ts
@@ -5,11 +5,11 @@ import {
   deleteSearch,
 } from "../controllers/searchFilterController";
 import { validateSearch } from "../middleware/searchFilterValidation";
-import { requireAuth } from "@clerk/express"; 
+
 const router = Router();
 
 router.get("/", getSearchHistory);
 router.post("/", validateSearch, createSearch);
-router.delete("/:id", requireAuth(), deleteSearch);
+router.delete("/:id", deleteSearch);
 
 export default router;

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -6,14 +6,22 @@ import cors from "cors";
 import dotenv from "dotenv";
 import morgan from "morgan";
 import bookRoutes from "./routes/bookRoutes";
+import { clerkAuth, attachAuth } from "./middleware/auth";
 
 dotenv.config()
 
 const app = express();
 
 app.use(morgan("combined"))
-app.use(cors())
+
 app.use(express.json());
+
+app.use(
+  cors({
+    origin: "http://localhost:5173",
+    credentials: true,
+  })
+);
 
 app.use(
   clerkMiddleware({
@@ -21,6 +29,9 @@ app.use(
     secretKey: process.env.CLERK_SECRET_KEY!,
   })
 );
+
+app.use(clerkAuth);
+app.use(attachAuth);
 
 
 app.get("/", (req, res) => {

--- a/apps/backend/src/services/searchFilterService.ts
+++ b/apps/backend/src/services/searchFilterService.ts
@@ -1,21 +1,22 @@
 import { prisma } from "./prisma"; 
 
 export const searchFilterService = {
-  async getAll() {
+  async getAll(userId: number) {
     return prisma.searchFilter.findMany({
+      where:{ userId },
       orderBy: { id: "desc" },
     });
   },
 
-  async create(term: string) {
+  async create(term: string, userId: number) {
     return prisma.searchFilter.create({
-      data: { term },
+      data: { term, userId },
     });
   },
 
-  async remove(id: number) {
+  async remove(id: number, userId: number) {
     return prisma.searchFilter.delete({
-      where: { id },
+      where: { id, userId },
     });
   },
 };

--- a/apps/backend/types/express.d.ts
+++ b/apps/backend/types/express.d.ts
@@ -1,3 +1,4 @@
+import "express";
 import { AuthObject } from "@clerk/express";
 
 declare global {

--- a/apps/frontend/src/Components/common/layout/nav/Nav.tsx
+++ b/apps/frontend/src/Components/common/layout/nav/Nav.tsx
@@ -17,6 +17,10 @@ export function Nav() {
           Home
         </NavLink>
 
+        <NavLink to="/Login">
+          Login
+        </NavLink>
+
         <NavLink to="/searchfilter">
           Search Filter
         </NavLink>

--- a/apps/frontend/src/Components/searchFilter/Searchfilter.tsx
+++ b/apps/frontend/src/Components/searchFilter/Searchfilter.tsx
@@ -1,7 +1,10 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { useAuth } from "@clerk/clerk-react";
 import type { SearchFilter as SearchFilterType } from "../../types/SearchFilter";
 import { searchService } from "../../services/searchfilterService";
+
+const API_URL = "http://localhost:3000/search-history";
 
 export default function SearchFilter({
   search,
@@ -11,22 +14,19 @@ export default function SearchFilter({
   setSearch: React.Dispatch<React.SetStateAction<string>>;
 }) {
   const navigate = useNavigate();
+  const { getToken } = useAuth();
+
   const [history, setHistory] = useState<SearchFilterType[]>([]);
   const [inputValue, setInputValue] = useState(search);
-  const [loading, setLoading] = useState(false);
 
+  // GET history
   const fetchHistory = async () => {
     try {
-      setLoading(true);
-      const response = await fetch("http://localhost:3000/search-history");
-      if (!response.ok) throw new Error("Failed to fetch");
-      const data = await response.json();
-      setHistory(Array.isArray(data) ? data : []);
+      const res = await fetch(API_URL);
+      const data = await res.json();
+      setHistory(data);
     } catch (error) {
-      console.error("Fetch error:", error);
-      setHistory([]);
-    } finally {
-      setLoading(false);
+      console.error("Failed to fetch history:", error);
     }
   };
 
@@ -34,42 +34,49 @@ export default function SearchFilter({
     fetchHistory();
   }, []);
 
+  // CREATE search 
   const handleSearch = async () => {
-    if (!inputValue.trim()) {
-      alert("Enter a search term");
-      return;
-    }
-
     const result = searchService.validateSearch(inputValue);
+
     if (!result.valid) {
       alert(result.message);
       return;
     }
 
     try {
-      const response = await fetch("http://localhost:3000/search-history", {
+      const token = await getToken();
+
+      await fetch(API_URL, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`, 
+        },
         body: JSON.stringify({ term: inputValue }),
       });
 
-      if (!response.ok) throw new Error("Save failed");
-
       await fetchHistory();
-      setSearch(inputValue);
-      navigate("/booklist");
     } catch (error) {
       console.error("Save error:", error);
     }
+
+    setSearch(inputValue);
+    setInputValue("");
+    navigate("/booklist");
   };
 
+  // DELETE 
   const handleRemove = async (id: number) => {
     try {
-      const response = await fetch(
-        `http://localhost:3000/search-history/${id}`,
-        { method: "DELETE" }
-      );
-      if (!response.ok) throw new Error("Delete failed");
+      const token = await getToken();
+
+      await fetch(`${API_URL}/${id}`, {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${token}`, 
+        },
+      });
+
       await fetchHistory();
     } catch (error) {
       console.error("Delete error:", error);
@@ -78,7 +85,12 @@ export default function SearchFilter({
 
   return (
     <div className="search-filter">
-      <div>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleSearch();
+        }}
+      >
         <input
           type="text"
           placeholder="Search Book..."
@@ -86,30 +98,29 @@ export default function SearchFilter({
           onChange={(e) => setInputValue(e.target.value)}
           className="filter-input"
         />
-        <button onClick={handleSearch} className="search-btn">
+
+        <button type="submit" className="search-btn">
           Search
         </button>
+      </form>
+
+      <div className="history-container">
+        {history.length > 0 && (
+          <ul className="history-list">
+            {history.map((item) => (
+              <li key={item.id} className="history-item">
+                {item.term}
+                <button
+                  onClick={() => handleRemove(item.id)}
+                  className="remove-btn"
+                >
+                  Remove
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
-
-      {loading && <p>Loading...</p>}
-
-      {!loading && history.length === 0 && <p>No search history found</p>}
-
-      {history.length > 0 && (
-        <ul className="history-list">
-          {history.map((item) => (
-            <li key={item.id}>
-              {item.term}
-              <button
-                onClick={() => handleRemove(item.id)}
-                className="remove-btn"
-              >
-                Remove
-              </button>
-            </li>
-          ))}
-        </ul>
-      )}
     </div>
   );
 }

--- a/apps/frontend/src/Components/searchFilter/Searchfilter.tsx
+++ b/apps/frontend/src/Components/searchFilter/Searchfilter.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { useAuth } from "@clerk/clerk-react";
+import { useAuth, useUser } from "@clerk/clerk-react";
 import type { SearchFilter as SearchFilterType } from "../../types/SearchFilter";
 import { searchService } from "../../services/searchfilterService";
 
@@ -14,15 +14,29 @@ export default function SearchFilter({
   setSearch: React.Dispatch<React.SetStateAction<string>>;
 }) {
   const navigate = useNavigate();
+
   const { getToken } = useAuth();
+  const { isSignedIn } = useUser();
 
   const [history, setHistory] = useState<SearchFilterType[]>([]);
   const [inputValue, setInputValue] = useState(search);
 
-  // GET history
+  // GET history 
   const fetchHistory = async () => {
     try {
-      const res = await fetch(API_URL);
+      if (!isSignedIn) {
+        setHistory([]);
+        return;
+      }
+
+      const token = await getToken();
+
+      const res = await fetch(API_URL, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
       const data = await res.json();
       setHistory(data);
     } catch (error) {
@@ -32,9 +46,9 @@ export default function SearchFilter({
 
   useEffect(() => {
     fetchHistory();
-  }, []);
+  }, [isSignedIn]);
 
-  // CREATE search 
+  // SEARCH (create)
   const handleSearch = async () => {
     const result = searchService.validateSearch(inputValue);
 
@@ -43,6 +57,15 @@ export default function SearchFilter({
       return;
     }
 
+    // Guest user 
+    if (!isSignedIn) {
+      setSearch(inputValue);
+      setInputValue("");
+      navigate("/booklist");
+      return;
+    }
+
+    // Logged-in user 
     try {
       const token = await getToken();
 
@@ -50,7 +73,7 @@ export default function SearchFilter({
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`, 
+          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({ term: inputValue }),
       });
@@ -65,15 +88,17 @@ export default function SearchFilter({
     navigate("/booklist");
   };
 
-  // DELETE 
+  // DELETE history
   const handleRemove = async (id: number) => {
+    if (!isSignedIn) return;
+
     try {
       const token = await getToken();
 
       await fetch(`${API_URL}/${id}`, {
         method: "DELETE",
         headers: {
-          Authorization: `Bearer ${token}`, 
+          Authorization: `Bearer ${token}`,
         },
       });
 
@@ -105,7 +130,7 @@ export default function SearchFilter({
       </form>
 
       <div className="history-container">
-        {history.length > 0 && (
+        {isSignedIn && history.length > 0 && (
           <ul className="history-list">
             {history.map((item) => (
               <li key={item.id} className="history-item">


### PR DESCRIPTION
This feature adds user-specific search history using Clerk authentication and Prisma. Logged-in users can save, view, and delete their own search history, while guest users can still search without storing any data. The backend uses the Clerk session token to identify the user and link search records through `clerkId`, and the frontend sends this token in all API requests for secure access.
